### PR TITLE
Fix weight_smoothing Function

### DIFF
--- a/pncc.py
+++ b/pncc.py
@@ -67,7 +67,7 @@ def weight_smoothing(final_output, medium_time_power, N=4, L=128):
         for l in range(final_output.shape[1]):
             l_1 = max(l - N, 1)
             l_2 = min(l + N, L)
-        spectral_weight_smoothing[m, l] = (1/float(l_2 - l_1 + 1)) * \
+            spectral_weight_smoothing[m, l] = (1/float(l_2 - l_1 + 1)) * \
             sum([(final_output[m, l_] / medium_time_power[m, l_])
                  for l_ in range(l_1, l_2)])
     return spectral_weight_smoothing


### PR DESCRIPTION
The weight_smoothing function had an error. It required 4 more spaces as shown in the changes. Earlier all the columns were coming zero except the last column in the spectral_weight_smoothing matrix because the for loop wasn't running completely.